### PR TITLE
Segmentation fault fix

### DIFF
--- a/src/SegmentGraph.cpp
+++ b/src/SegmentGraph.cpp
@@ -94,11 +94,14 @@ SegmentGraph_t::SegmentGraph_t(const vector<int>& RefLength, SBamrecord_t& Chimr
 	// TmpWriteBEDPE("tmpedges2_before_filteredges.txt", *this, RefName);
 	FilterEdges(KeepEdge);
 	// TmpWriteBEDPE("tmpedges2_before_compressnode.txt", *this, RefName);
-	CompressNode();
-	FurtherCompressNode();
-	// TmpWriteBEDPE("tmpedges2_before_almostdone.txt", *this, RefName);
-	ConnectedComponent();
-	MultiplyDisEdges();
+
+	if (vNodes.size() > 0) {
+		CompressNode();
+		FurtherCompressNode();
+		// TmpWriteBEDPE("tmpedges2_before_almostdone.txt", *this, RefName);
+		ConnectedComponent();
+		MultiplyDisEdges();
+	}
 	cout<<vNodes.size()<<'\t'<<vEdges.size()<<endl;
 };
 
@@ -732,9 +735,11 @@ void SegmentGraph_t::BuildNode_STAR(const vector<int>& RefLength, SBamrecord_t& 
 		Node_t tmp(tmpNodes.back().Chr, tmpNodes.back().Position+tmpNodes.back().Length, RefLength[tmpNodes.back().Chr]-tmpNodes.back().Position-tmpNodes.back().Length);
 		tmpNodes.push_back(tmp);
 	}
-	for(int chrstart=tmpNodes.back().Chr+1; chrstart<RefLength.size(); chrstart++){
-		Node_t tmp(chrstart, 0, RefLength[chrstart]);
-		tmpNodes.push_back(tmp);
+	if(tmpNodes.size()!=0) {
+		for(int chrstart=tmpNodes.back().Chr+1; chrstart<RefLength.size(); chrstart++){
+			Node_t tmp(chrstart, 0, RefLength[chrstart]);
+			tmpNodes.push_back(tmp);
+		}
 	}
 	vNodes=tmpNodes; tmpNodes.clear();
 	time(&CurrentTime);
@@ -1187,6 +1192,8 @@ vector<int> SegmentGraph_t::LocateRead(int initialguess, ReadRec_t& ReadRec){
 	for(int k=0; k<ReadRec.FirstRead.size(); k++){
 		if(i<0 || i>=vNodes.size())
 			i=initialguess;
+		if (i >= vNodes.size())
+			break;
 		if(!(vNodes[i].Chr==ReadRec.FirstRead[k].RefID && ReadRec.FirstRead[k].RefPos>=vNodes[i].Position-thresh && ReadRec.FirstRead[k].RefPos+ReadRec.FirstRead[k].MatchRef<=vNodes[i].Position+vNodes[i].Length+thresh)){
 			if(vNodes[i].Chr<ReadRec.FirstRead[k].RefID || (vNodes[i].Chr==ReadRec.FirstRead[k].RefID && vNodes[i].Position<=ReadRec.FirstRead[k].RefPos)){
 				for(; i<vNodes.size() && vNodes[i].Chr<=ReadRec.FirstRead[k].RefID; i++)
@@ -1228,6 +1235,8 @@ vector<int> SegmentGraph_t::LocateRead(int initialguess, ReadRec_t& ReadRec){
 	for(int k=0; k<ReadRec.SecondMate.size(); k++){
 		if(i<0 || i>=vNodes.size())
 			i=initialguess;
+		if (i >= vNodes.size())
+			break;
 		if(!(vNodes[i].Chr==ReadRec.SecondMate[k].RefID && ReadRec.SecondMate[k].RefPos>=vNodes[i].Position-thresh && ReadRec.SecondMate[k].RefPos+ReadRec.SecondMate[k].MatchRef<=vNodes[i].Position+vNodes[i].Length+thresh)){
 			if(vNodes[i].Chr<ReadRec.SecondMate[k].RefID || (vNodes[i].Chr==ReadRec.SecondMate[k].RefID && vNodes[i].Position<=ReadRec.SecondMate[k].RefPos)){
 				for(; i<vNodes.size() && vNodes[i].Chr<=ReadRec.SecondMate[k].RefID; i++)
@@ -3233,7 +3242,9 @@ vector< vector<int> > SegmentGraph_t::Ordering(){
 			continue;
 		}
 		//cout<<"component "<<i<<"\t"<<CompNodes.size()<<endl;
-		BestOrders[i]=MincutRecursion(CompNodes, CompEdges);
+		if (CompNodes.size() > 0) {
+			BestOrders[i]=MincutRecursion(CompNodes, CompEdges);
+		}
 	}
 	return BestOrders;
 };

--- a/src/WriteIO.cpp
+++ b/src/WriteIO.cpp
@@ -35,9 +35,11 @@ void WriteComponents(string outputfile, vector< vector<int> > Components){
 	output<<"# component_id\tnodes\n";
 	for(int i=0; i<Components.size(); i++){
 		output<<i<<'\t';
-		for(int j=0; j<Components[i].size()-1; j++)
+		for(int j=0; j+1<Components[i].size(); j++)
 			output<<Components[i][j]<<",";
-		output<<Components[i][Components[i].size()-1]<<endl;
+		if (Components[i].size() > 0) {
+			output<<Components[i][Components[i].size()-1]<<endl;
+		}
 	}
 	output.close();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,10 +42,12 @@ int main(int argc, char* argv[]){
 		if(Print_Components_Ordering)
 			WriteComponents(Output_Prefix+"_component_pri.txt", Components);
 
-		Components=SegmentGraph.SortComponents(Components);
-		Components=SegmentGraph.MergeSingleton(Components, RefLength);
-		Components=SegmentGraph.SortComponents(Components);
-		Components=SegmentGraph.MergeComponents(Components);
+		if (SegmentGraph.vNodes.size() > 0) {
+			Components=SegmentGraph.SortComponents(Components);
+			Components=SegmentGraph.MergeSingleton(Components, RefLength);
+			Components=SegmentGraph.SortComponents(Components);
+			Components=SegmentGraph.MergeComponents(Components);
+		}
 
 		vector< pair<int, int> > Node_NewChr; Node_NewChr.resize(SegmentGraph.vNodes.size());
 		for(unsigned int i=0; i<Components.size(); i++)


### PR DESCRIPTION
This PR fixes the segmentation faults in the case that 0 discordant edges are detected by squid. 
Here, extra checks are added and the original workflow continues to be the same to produce all the required output files.